### PR TITLE
updated versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject org.clojars.carocad/docopt "0.1.0"
+(defproject org.clojars.carocad/docopt "0.1.1"
   :description "Docopt creates beautiful command-line interfaces - clojure (unnoficial) port"
   :url "https://github.com/carocad/docopt.cluno"
   :license {:name "MIT" :url "https://raw.githubusercontent.com/carocad/docopt.cluno/master/LICENSE"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [instaparse "1.4.1"]]
-  :profiles {:test {:dependencies [[org.clojure/data.json "0.2.1"]]}}
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [instaparse "1.4.5"]]
+  :profiles {:test {:dependencies [[org.clojure/data.json "0.2.6"]]}}
   ;:main ^:skip-aot docopt.main
   :aot :all)


### PR DESCRIPTION
I know this doesn’t help much. It’s my first attempt. I’m a noob. I’m trying to trace the source of:
> Caused by: java.lang.ClassCastException: java.lang.Long cannot be cast to clojure.lang.Associative
>	at clojure.lang.RT.assoc(RT.java:792)
>	at clojure.core$assoc__4371.invokeStatic(core.clj:191)
>	at clojure.core$assoc__4371.invoke(core.clj:190)
>	at instaparse.reduction$apply_standard_reductions$iter__241__245$fn__246.invoke(reduction.clj:54)
>	at clojure.lang.LazySeq.sval(LazySeq.java:40)
>	at clojure.lang.LazySeq.seq(LazySeq.java:49)
>	at clojure.lang.RT.seq(RT.java:521)
>	at clojure.core$seq__4357.invokeStatic(core.clj:137)
>	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:24)
>	at clojure.core.protocols$fn__6738.invokeStatic(protocols.clj:75)
>	at clojure.core.protocols$fn__6738.invoke(protocols.clj:75)
>	at clojure.core.protocols$fn__6684$G__6679__6697.invoke(protocols.clj:13)
>	at clojure.core$reduce.invokeStatic(core.clj:6545)
>	at clojure.core$into.invokeStatic(core.clj:6610)
>	at clojure.core$into.invoke(core.clj:6604)
>	at instaparse.reduction$apply_standard_reductions.invokeStatic(reduction.clj:52)
>	at instaparse.reduction$apply_standard_reductions.invoke(reduction.clj:48)
>	at instaparse.cfg$build_parser_from_combinators.invokeStatic(cfg.clj:292)
>	at instaparse.cfg$build_parser_from_combinators.invoke(cfg.clj:288)
>	at instaparse.core$parser.invokeStatic(core.clj:248)
>	at instaparse.core$parser.doInvoke(core.clj:171)
>	at clojure.lang.RestFn.invoke(RestFn.java:486)
>	at docopt.core$docopt.invokeStatic(core.clj:155)
>	at docopt.core$docopt.invoke(core.clj:140)
>	at docopt.core$docopt.invokeStatic(core.clj:150)
>	at docopt.core$docopt.invoke(core.clj:140)
